### PR TITLE
Add Refresh Token Into Flow

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -63,8 +63,12 @@ root.render(
         <Auth0Provider
           domain={Constants.AUTH0_DOMAIN}
           clientId={Constants.AUTH0_CLIENT}
+          
+          useRefreshTokens={true}
           authorizationParams={{
             redirect_uri: window.location.origin,
+            audience: Constants.AUTH0_AUDIENCE,
+            // scope: 'openid profile email offline_access',
           }}
         >
           <RouterProvider router={router} />


### PR DESCRIPTION
As simple as adding some flags to the provider for Auth0, add refresh tokens to the flow on the frontend. This enables working in Chrome incognito where it did not before. Safari still doesn't work.